### PR TITLE
Fixed path to ingress-bad.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ kubectl create ns qa
 The following call should fail with policy:
 
 ```bash
-kubectl -n qa apply -f ~/opa/ingress-bad.yaml
+kubectl -n qa apply -f ./demo/ingress-bad.yaml
 ```
 
 ## 2. `mutation` scenario


### PR DESCRIPTION
Fixed path to ingress-bad.yaml, as it was pointing to ~/opa/ingress-bad.yaml and not ./demo/ingress-bad.yaml