### PR TITLE
Fix delete all script

### DIFF
--- a/deploy/delete-all.sh
+++ b/deploy/delete-all.sh
@@ -4,6 +4,8 @@ echo "Delete all will delete all kubebernetes-policy-controller components"
 
 read -p "Press enter to continue"
 
+rm -rf ./secret
+
 kubectl -n opa delete mutatingwebhookconfiguration mutating.kubernetes-policy-controller
 kubectl delete -n opa -f ./deploy/opa.yaml
 kubectl -n opa delete secret opa-server

--- a/deploy/delete-all.sh
+++ b/deploy/delete-all.sh
@@ -5,7 +5,7 @@ echo "Delete all will delete all kubebernetes-policy-controller components"
 read -p "Press enter to continue"
 
 kubectl -n opa delete mutatingwebhookconfiguration mutating.kubernetes-policy-controller
-kubectl delete -n opa -f ./opa.yaml
+kubectl delete -n opa -f ./deploy/opa.yaml
 kubectl -n opa delete secret opa-server
 kubectl -n opa delete configmap ingress-conflict 
 kubectl -n opa delete configmap ingress-host-fqdn 


### PR DESCRIPTION
deploy-all.sh script is expected to run from root. All path are set accordingly in this script.
On the similar ground from delete-all.sh script should run from root too and the opa.yaml path is adjusted to make it consistent.
Also delete-all.sh now removes "secret" directory too, making it clean delete on local.